### PR TITLE
Стилизация navbar (и элементов material ui в принципе) и рабочий селект

### DIFF
--- a/src/components/Navigation/navigation.scss
+++ b/src/components/Navigation/navigation.scss
@@ -3,24 +3,21 @@
   background-color: #373737;
   flex-wrap: wrap;
   justify-content: space-around;
-  max-width: 1024px;
-  margin: 0 auto;
   padding: 0;
   box-sizing: border-box; 
+  height: 60px;
   }
 
 .nav-button {
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 60px;  
 }
 
 .nav-link {
   text-decoration: none;
   padding: 6px 16px;
-  color: #373737;
-  background-color: #F5F5F5;
+  color: #f5f5f5;
   border-radius: 4px;
   transition: color 0.8s ease-in-out;
   &:hover {
@@ -30,7 +27,7 @@
 }
 
 .active {
-  color: green;
+  text-decoration: underline;
 }
 
 @media (max-width: 720px) {

--- a/src/containers/main_page/MainPage.js
+++ b/src/containers/main_page/MainPage.js
@@ -12,14 +12,15 @@ export default function MainPage() {
     (async () => {
       const result = await getDirectorOfDay();
       setDirector(result);
+      console.log(result);
     })();
-  });
+  }, []);
 
   const renderDirector = () => {
     return (
       <div className={styles.cardContent}>
-        <img className={styles.photo} src={director.photo} alt="director of the day photo" />
-        <div className={styles.cardText} gutterBottom>
+        <img className={styles.photo} src={director.photo} alt="director of the day" />
+        <div className={styles.cardText}>
           <Typography variant="h2" style={{ fontSize: '40px' }} color="primary">
             {director.name[language]}
           </Typography>

--- a/src/containers/main_page/MainPage.js
+++ b/src/containers/main_page/MainPage.js
@@ -12,7 +12,6 @@ export default function MainPage() {
     (async () => {
       const result = await getDirectorOfDay();
       setDirector(result);
-      console.log(result);
     })();
   }, []);
 

--- a/src/containers/styleguide/Styleguide.js
+++ b/src/containers/styleguide/Styleguide.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import styles from './Styleguide.module.css';
 import { Typography, Button, Select, MenuItem, TextField } from '@material-ui/core/';
 import VideoLibraryIcon from '@material-ui/icons/VideoLibrary';
@@ -7,8 +7,10 @@ import HomeIcon from '@material-ui/icons/Home';
 import ListIcon from '@material-ui/icons/List';
 import MapIcon from '@material-ui/icons/Map';
 import PhotoLibraryIcon from '@material-ui/icons/PhotoLibrary';
+import languageContext from '../../context/languageContext';
 
 export default function Styleguide() {
+  const { language, changeLanguage } = useContext(languageContext);
   return (
     <div className={styles.wrapper}>
       <section className={styles.section}>
@@ -33,24 +35,26 @@ export default function Styleguide() {
           Inputs
         </Typography>
         <TextField label="Search" variant="outlined" />
-        <Select 
+        <Select
           variant="outlined"
-          value="en"
-          onChange={(e) => e.preventDefault()}
-          style={{marginLeft: '2%'}}
+          value={language}
+          onChange={e => {
+            changeLanguage(e.target.value);
+          }}
+          style={{ marginLeft: '2%' }}
         >
           <MenuItem value="en">EN</MenuItem>
           <MenuItem value="ru">RU</MenuItem>
-          <MenuItem value="by">BY</MenuItem>
+          <MenuItem value="bl">BY</MenuItem>
         </Select>
       </section>
       <section className={styles.section}>
         <Typography variant="h4" gutterBottom>
           Buttons
         </Typography>
-        <Button variant="contained" color="primary">Learn more</Button>
-        <Button variant="outlined" color="primary">Узнать больше</Button>
-        <Button variant="contained" color="primary">
+        <Button size="small" variant="contained" color="primary">Learn more</Button>
+        <Button size="medium" variant="outlined" color="primary">Узнать больше</Button>
+        <Button size="large" variant="contained" color="primary">
           <VideoLibraryIcon style={{ fontSize: 28 }} />
         </Button>
       </section>


### PR DESCRIPTION
Уже готовый, рабочий селект лежит в компоненте Styleguide, но чтобы его использовать, надо будет переделать Navigation из класса в функциональный компонент (т. к. контекст на классах не работает). 
По поводу стилизации компонентов. Если просто нужно поменять размер, то можно сделать это следующим образом:
https://i.ibb.co/YQ26nSw/button-sizes.png
Если нужны более глобальные изменения (цвет и др.), то это можно сделать так:
https://i.ibb.co/zN35PTL/button-colors.png
На всякий случай сделал вот такой вариант стилизации, может понравится:
https://i.ibb.co/J5Rs5Mp/main-page.png
Для этого поменял немного содержимое navigation.scss